### PR TITLE
Install hirak/prestissimo composer plugin

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,13 @@
     mode: "0777"
   tags: composer
 
+- name: install hirak/prestissimo (composer)
+  composer:
+    command: require
+    arguments: hirak/prestissimo
+    prefer_dist: yes
+    global_command: yes
+
 - name: create php-fpm pools
   become: yes
   template:


### PR DESCRIPTION
This PR adds hirak/prestissimo composer plugin.

The package allows to parallelize composer install, granting a huge speedup.

The same functionality should be introduced by composer 2.0, which is currently in alpha.